### PR TITLE
Add local PDF viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # FutureOfFlow
+
+This repository includes a simple script for serving a PDF via a local web page.
+
+## Usage
+1. Place the PDF you want to view in this directory and name it `document.pdf`.
+2. Run the server:
+
+```bash
+python server.py
+```
+
+3. Open [http://localhost:8000](http://localhost:8000) in your browser to view the PDF.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PDF Viewer</title>
+  <style>
+    html, body, iframe {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <iframe src="document.pdf" width="100%" height="100%" frameborder="0" allowfullscreen>
+    <p>Your browser does not support iframes.</p>
+  </iframe>
+</body>
+</html>

--- a/server.py
+++ b/server.py
@@ -1,0 +1,10 @@
+import http.server
+import socketserver
+
+PORT = 8000
+
+Handler = http.server.SimpleHTTPRequestHandler
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print(f"Serving at http://localhost:{PORT}")
+    httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add `index.html` to embed a PDF file
- add `server.py` to serve the site with Python
- explain usage in README

## Testing
- `python3 -m py_compile server.py`
- `python3 server.py & sleep 2; pgrep -f server.py; kill $! >/dev/null 2>&1`

------
https://chatgpt.com/codex/tasks/task_b_68504b8c64988331b0e77d44ddc271ca